### PR TITLE
update wrong comparison

### DIFF
--- a/assertions/src/PhyLockAssertion.a.sol
+++ b/assertions/src/PhyLockAssertion.a.sol
@@ -96,9 +96,9 @@ contract PhyLockAssertion is Assertion {
         }
 
         // Calculate the expected sum of positions after withdrawals
-        uint256 expectedPositionChangesSum = prePositionChangesSum - expectedChange;
+        uint256 expectedPositionChangesSum = prePositionChangesSum - postPositionChangesSum;
 
         // Verify that the sum of remaining positions matches the expected amount
-        require(postPositionChangesSum == expectedPositionChangesSum, "Withdraw invariant violated");
+        require(expectedChange == expectedPositionChangesSum, "Withdraw invariant violated");
     }
 }


### PR DESCRIPTION
Fix the bug where all assertion tests pass for withdraw, but it fails on chain.

The problem is that a regular withdraw is reverting an assertion and this shouldn't happen.

Current state: fixed the assertion to be more clear, but still fails onchain, while tests pass.