### PR TITLE
remove broadcast from commands and fix broken withdraw command

### DIFF
--- a/assertions/src/PriceFeedAssertion.a.sol
+++ b/assertions/src/PriceFeedAssertion.a.sol
@@ -12,7 +12,7 @@ contract PriceFeedAssertion is Assertion {
     }
 
     function triggers() external view override {
-        registerCallTrigger(this.assertionPriceDeviation.selector);
+        registerCallTrigger(this.assertionPriceDeviation.selector, tokenPriceFeed.setPrice.selector);
     }
 
     function assertionPriceDeviation() external {

--- a/assertions/test/PriceFeedAssertion.t.sol
+++ b/assertions/test/PriceFeedAssertion.t.sol
@@ -57,6 +57,29 @@ contract TestPriceFeedAssertion is CredibleTest, Test {
             abi.encodeWithSelector(MockTokenPriceFeed.setPrice.selector, 1.05 ether)
         );
     }
+
+    function testUnsafePriceUpdate() public {
+        vm.prank(address(0xdeadbeef));
+        // Set initial token price
+        assertionAdopter.setPrice(1 ether);
+
+        cl.addAssertion(
+            "PriceFeedAssertion",
+            address(assertionAdopter),
+            type(PriceFeedAssertion).creationCode,
+            abi.encode(address(assertionAdopter))
+        );
+
+        // Update price within allowed range (5% increase)
+        vm.prank(address(0xdeadbeef));
+        vm.expectRevert("Assertions Reverted");
+        cl.validate(
+            "PriceFeedAssertion",
+            address(assertionAdopter),
+            0,
+            abi.encodeWithSelector(MockTokenPriceFeed.setPrice.selector, 0.75 ether)
+        );
+    }
 }
 
 contract BatchTokenPriceUpdates {

--- a/script/DeploySimpleLending.s.sol
+++ b/script/DeploySimpleLending.s.sol
@@ -37,8 +37,8 @@ contract DeployScript is Script {
         console.log("Token Price Feed deployed at:", address(tokenPriceFeed));
 
         // Set initial prices (in USD with 18 decimals)
-        ethPriceFeed.setPrice(2000 * 10 ** 18); // $2000 per ETH
-        tokenPriceFeed.setPrice(1 * 10 ** 18); // $1 per token
+        ethPriceFeed.setPrice(2000 ether); // $2000 per ETH
+        tokenPriceFeed.setPrice(1 ether); // $1 per token
 
         // Deploy SimpleLending contract
         SimpleLending lending = new SimpleLending(address(mockToken), address(ethPriceFeed), address(tokenPriceFeed));


### PR DESCRIPTION
* add `--tc` flag to DeploySimpleLending command
* remove `--broadcast` flag
* fix bug in withdraw value in SimpleLending
* add additional pricefeed test
* additional explanation of assertion activation for each example