### PR TITLE
remove constructor arg from commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,13 +312,7 @@ This is a known limitation of the system - when an assertion reverts a transacti
 We recommend doing a simple ether transfer with a higher gas price, to replace the dropped transaction:
 
 ```bash
-cast nonce <your-address> --rpc-url <your-rpc>
-```
-
-and then use the nonce to send a new transaction:
-
-```bash
-cast send <your-address> --value 0 --gas-price <higher-gas-price> --nonce <nonce> --private-key <your-private-key> --rpc-url <your-rpc>
+cast send <your-address> --value 0 --gas-price <higher-gas-price> --private-key <your-private-key> --rpc-url <your-rpc>
 ```
 
 This command will send a 0 ETH transaction to your own address with the specified gas price, effectively replacing any stuck transactions. If it doesn't work try increasing the gas price further.

--- a/README.md
+++ b/README.md
@@ -124,16 +124,16 @@ Once a project is created you can store assertions for it.
 To store assertions, run:
 
 ```bash
-pcl store <assertion-name> <constructor-args>
+pcl store <assertion-name>
 ```
 
-For example, to store the `OwnableAssertion` assertion with the constructor arguments `0x1234567890123456789012345678901234567890`:
+For example, to store the `OwnableAssertion` assertion:
 
 ```bash
-pcl store OwnableAssertion 0x1234567890123456789012345678901234567890
+pcl store OwnableAssertion
 ```
 
-This means that the assertion will be protecting the contract with address `0x1234567890123456789012345678901234567890`.
+All assertions contracts in this repository use the `ph.getAssertionAdopter` cheatcode, which can be used instead of defining the contract to protect in the constructor.
 
 ## Submitting Assertions
 
@@ -154,7 +154,7 @@ pcl submit -a <assertion-name> -p <project-name>
 For example, to submit the `OwnableAssertion` assertion to a project named `foobar`:
 
 ```bash
-pcl submit -a 'OwnableAssertion(0x1234567890123456789012345678901234567890)' -p foobar
+pcl submit -a 'OwnableAssertion' -p foobar
 ```
 
 This is assuming the project you created is named `foobar`.
@@ -174,37 +174,11 @@ Before you run the transactions you should make sure to store, submit and activa
 
 Note, for each of the protocols below, you can refer to the [Credible Layer Quickstart Guide](https://docs.phylax.systems/credible/pcl-quickstart) for more context and explanations on how to use the pcl and dapp to store, submit and activate assertions.
 
-When an assertion is reverted, the transaction causing the revert will be ignored by the builder. This means that the `cast` or `forge` command will not show any output indicating that the transaction was reverted, it will just timeout after a while. You can use the `--timeout` flag to decrease the timeout.
-
-```bash
-Error: transaction was not confirmed within the timeout
-```
-
-If you try to do another transaction with the same private key, you will most likely get this a replacement transaction error:
-
-```bash
-- server returned an error response: error code -32603: replacement transaction underpriced
-```
-
-This is a known limitation of the system - when an assertion reverts a transaction, it gets dropped by the builder rather than being included in a block. This means that wallets and tools like `cast` will still increment their local nonce, potentially causing issues with subsequent transactions. While this creates some UX friction, it only occurs when someone attempts to violate an assertion (i.e., attempt to hack a protocol), so we consider this an acceptable tradeoff. In the future, we plan to work with wallet providers to better surface these dropped transactions.
-
-We recommend doing a simple ether transfer with a higher gas price, to replace the dropped transaction:
-
-```bash
-cast nonce <your-address> --rpc-url <your-rpc>
-```
-
-and then use the nonce to send a new transaction:
-
-```bash
-cast send <your-address> --value 0 --gas-price <higher-gas-price> --nonce <nonce> --private-key <your-private-key> --rpc-url <your-rpc>
-```
-
-This command will send a 0 ETH transaction to your own address with the specified gas price, effectively replacing any stuck transactions. If it doesn't work try increasing the gas price further.
+If you run into a `replacement transaction underpriced` error, you can follow the steps in the [Stuck Transactions](#stuck-transactions) section to replace the dropped transaction.
 
 ### PhyLock
 
-A staking protocol that allows users to deposit ETH and earn Phylax tokens as rewards.
+A staking protocol that allows users to deposit ETH and earn Phylax tokens as rewards. (You can add the token to your browser wallet by pasting the PhyLock Token address that was returned by the deploy script.)
 It seems the developers have spent more time defining their invariants than actually implementing the protocol.
 Because of this there are critical bugs present in the protocol:
 
@@ -230,7 +204,7 @@ export RPC_URL=phylax_demo_rpc_url # phylax demo rpc url
 # Deposit 0.7 eth from the address of the private key - should succeed as it's intented behavior
 cast send $PHYLOCK_ADDRESS "deposit()" --value 0.7ether --private-key $PRIVATE_KEY --rpc-url $RPC_URL
 
-# Withdraw 0.2 eth from the address of the private key - should succeed as it's intented behavior (you received phylax tokens as a reward)
+# Withdraw 0.2 eth from the address of the private key - should succeed as it's intented behavior (you received phylax tokens as a reward for staking)
 cast send $PHYLOCK_ADDRESS "withdraw(uint256)" 0.2ether --private-key $PRIVATE_KEY --rpc-url $RPC_URL
 
 # Call withdraw with the magic number 69 ether - this should fail due to the assertion
@@ -316,3 +290,35 @@ cast call $OWNABLE_ADDRESS "owner()" --rpc-url $RPC_URL
 ## Additional Resources
 
 Please refer to the [Credible Layer Quickstart Guide](https://docs.phylax.systems/credible/pcl-quickstart) for comprehensive documentation on the Credible Layer and guides for getting started.
+
+## Troubleshooting
+
+### Stuck Transactions
+
+When an assertion is reverted, the transaction causing the revert will be ignored by the builder. This means that the `cast` or `forge` command will not show any output indicating that the transaction was reverted, it will just timeout after a while. You can use the `--timeout` flag to decrease the timeout.
+
+```bash
+Error: transaction was not confirmed within the timeout
+```
+
+If you try to do another transaction with the same private key, you will most likely get this a replacement transaction error:
+
+```bash
+- server returned an error response: error code -32603: replacement transaction underpriced
+```
+
+This is a known limitation of the system - when an assertion reverts a transaction, it gets dropped by the builder rather than being included in a block. This means that wallets and tools like `cast` will still increment their local nonce, potentially causing issues with subsequent transactions. While this creates some UX friction, it only occurs when someone attempts to violate an assertion (i.e., attempt to hack a protocol), so we consider this an acceptable tradeoff. In the future, we plan to work with wallet providers to better surface these dropped transactions.
+
+We recommend doing a simple ether transfer with a higher gas price, to replace the dropped transaction:
+
+```bash
+cast nonce <your-address> --rpc-url <your-rpc>
+```
+
+and then use the nonce to send a new transaction:
+
+```bash
+cast send <your-address> --value 0 --gas-price <higher-gas-price> --nonce <nonce> --private-key <your-private-key> --rpc-url <your-rpc>
+```
+
+This command will send a 0 ETH transaction to your own address with the specified gas price, effectively replacing any stuck transactions. If it doesn't work try increasing the gas price further.


### PR DESCRIPTION
Remove constructor args in the store and submit pcl commands

Move stuck tx fix to the bottom of the document

Small formulation nits