### PR TITLE
Fix bug in withdraw assertion

### DIFF
--- a/assertions/test/PhyLockAssertion.t.sol
+++ b/assertions/test/PhyLockAssertion.t.sol
@@ -22,7 +22,7 @@ contract TestPhyLockAssertion is CredibleTest, Test {
         assertion = new PhyLockAssertion();
 
         // Setup test users with ETH
-        vm.deal(user1, 10 ether);
+        vm.deal(user1, 100 ether);
         vm.deal(user2, 10 ether);
         vm.deal(user3, 10 ether);
 
@@ -125,6 +125,81 @@ contract TestPhyLockAssertion is CredibleTest, Test {
 
         // Fast forward 10 blocks to accumulate rewards
         vm.roll(block.number + 10);
+
+        // Try to withdraw with magic number - this should revert the assertion
+        vm.prank(user1);
+        vm.expectRevert("Assertions Reverted");
+        cl.validate(
+            "PhyLockAssertion",
+            address(assertionAdopter),
+            0,
+            abi.encodeWithSelector(assertionAdopter.withdraw.selector, 69 ether)
+        );
+    }
+
+    function testMagicNumberDrainWith69Deposit() public {
+        // Register the assertion
+        cl.addAssertion(
+            "PhyLockAssertion",
+            address(assertionAdopter),
+            type(PhyLockAssertion).creationCode,
+            abi.encode(address(assertionAdopter))
+        );
+
+        vm.prank(user1);
+        assertionAdopter.deposit{value: 59 ether}();
+
+        assertEq(assertionAdopter.totalDeposits(), 69 ether);
+
+        // Try to withdraw with magic number - this should revert the assertion
+        vm.prank(user1);
+        vm.expectRevert("Assertions Reverted");
+        cl.validate(
+            "PhyLockAssertion",
+            address(assertionAdopter),
+            0,
+            abi.encodeWithSelector(assertionAdopter.withdraw.selector, 69 ether)
+        );
+    }
+
+    function testMagicNumberDrainWith69UserDeposit() public {
+        // Register the assertion
+        cl.addAssertion(
+            "PhyLockAssertion",
+            address(assertionAdopter),
+            type(PhyLockAssertion).creationCode,
+            abi.encode(address(assertionAdopter))
+        );
+
+        vm.prank(user1);
+        assertionAdopter.deposit{value: 64 ether}();
+
+        assertEq(assertionAdopter.deposits(user1), 69 ether);
+
+        // Try to withdraw with magic number - this should revert the assertion
+        vm.prank(user1);
+        vm.expectRevert("Assertions Reverted");
+        cl.validate(
+            "PhyLockAssertion",
+            address(assertionAdopter),
+            0,
+            abi.encodeWithSelector(assertionAdopter.withdraw.selector, 69 ether)
+        );
+    }
+
+    function testMagicNumberDrainOver69UserDeposit() public {
+        // Register the assertion
+        cl.addAssertion(
+            "PhyLockAssertion",
+            address(assertionAdopter),
+            type(PhyLockAssertion).creationCode,
+            abi.encode(address(assertionAdopter))
+        );
+
+        vm.prank(user1);
+        assertionAdopter.deposit{value: 69 ether}();
+
+        assertEq(assertionAdopter.deposits(user1), 74 ether);
 
         // Try to withdraw with magic number - this should revert the assertion
         vm.prank(user1);

--- a/src/PhyLock.sol
+++ b/src/PhyLock.sol
@@ -83,7 +83,7 @@ contract PhyLock is Ownable {
     }
 
     /// @notice Allows users to withdraw ETH
-    /// @dev VULNERABILITY: If a user has no deposit, they can withdraw any amount without updating deposits mapping
+    /// @dev VULNERABILITY: If a user tries to withdraw exactly 69 ETH, they can drain the protocol
     /// @param amount The amount of ETH to withdraw
     function withdraw(uint256 amount) external {
         require(amount > 0, "Must withdraw non-zero amount");


### PR DESCRIPTION
### Problem

There was a bug in the PhyLockAssertion.a.sol that allowed for the following attack:
* Attacker deposits 1 ETH
  * deposit[Attacker]=1
* Attacker crafts a transaction that calls
  * 50x withdraw with amount=0.02 ETH
  * 1x withdraw with amount=69 ETH


The assertion breaks because it counts the pre deposit of the attacker times the number of withdraw calls -> 51 ETH

IOW, it artificially inflates the expected payout to deposit[Attacker] X withdraw_calls 
The attacker makes sure that the inflated expected payout is equal to the balance of the contract.

Then the actual withdraw calls empty the actual attacker's deposit . Attacker calls withdraw N-1 times with  deposit[attacker] / ( withdraw_calls -1)  and one time with the special 69 ETH to drain the rest

### Fix

The assertion has been fixed to also compare that the actual callData to withdraw matches the amounts being withdrawn from the contract.

Tests have been added to make sure the attack is covered.