### PR TITLE
Update assertion tests to new cl.assertion() interface

### DIFF
--- a/assertions/src/PhyLockAssertion.a.sol
+++ b/assertions/src/PhyLockAssertion.a.sol
@@ -93,6 +93,8 @@ contract PhyLockAssertion is Assertion {
 
             uint256 callerPostBalance = phyLock.deposits(calls[i].caller);
             postPositionChangesSum += callerPostBalance;
+            // Explicitly fail if the caller withdraws more than they have deposited instead of relying on arithmetic error
+            require(amount <= callerPreBalance, "Caller withdraw amount higher than deposit");
             require(callerPostBalance == callerPreBalance - amount, "Caller withdraw amount mismatch");
         }
 

--- a/assertions/test/OwnableAssertion.t.sol
+++ b/assertions/test/OwnableAssertion.t.sol
@@ -20,32 +20,28 @@ contract TestOwnableAssertion is CredibleTest, Test {
 
     // Test case: Ownership changes should trigger the assertion
     function test_assertionOwnershipChanged() public {
-        address aaAddress = address(assertionAdopter);
-        string memory label = "Ownership has changed";
-
-        // Associate the assertion with the protocol
-        // cl will manage the correct assertion execution when the protocol is called
-        cl.addAssertion(label, aaAddress, type(OwnableAssertion).creationCode, abi.encode(assertionAdopter));
+        cl.assertion({
+            adopter: address(assertionAdopter),
+            createData: type(OwnableAssertion).creationCode,
+            fnSelector: OwnableAssertion.assertionOwnershipChange.selector
+        });
 
         // Simulate a transaction that changes ownership
         vm.prank(initialOwner);
-        vm.expectRevert("Assertions Reverted");
-        cl.validate(
-            label, aaAddress, 0, abi.encodePacked(assertionAdopter.transferOwnership.selector, abi.encode(newOwner))
-        );
+        vm.expectRevert("Ownership has changed");
+        assertionAdopter.transferOwnership(newOwner);
     }
 
     // Test case: No ownership change should pass the assertion
     function test_assertionOwnershipNotChanged() public {
-        string memory label = "Ownership has not changed";
-        address aaAddress = address(assertionAdopter);
-
-        cl.addAssertion(label, aaAddress, type(OwnableAssertion).creationCode, abi.encode(assertionAdopter));
+        cl.assertion({
+            adopter: address(assertionAdopter),
+            createData: type(OwnableAssertion).creationCode,
+            fnSelector: OwnableAssertion.assertionOwnershipChange.selector
+        });
 
         // Simulate a transaction that doesn't change ownership (transferring to same owner)
         vm.prank(initialOwner);
-        cl.validate(
-            label, aaAddress, 0, abi.encodePacked(assertionAdopter.transferOwnership.selector, abi.encode(initialOwner))
-        );
+        assertionAdopter.transferOwnership(initialOwner);
     }
 }

--- a/assertions/test/OwnableAssertion.t.sol
+++ b/assertions/test/OwnableAssertion.t.sol
@@ -20,6 +20,8 @@ contract TestOwnableAssertion is CredibleTest, Test {
 
     // Test case: Ownership changes should trigger the assertion
     function test_assertionOwnershipChanged() public {
+        assertEq(assertionAdopter.owner(), initialOwner);
+
         cl.assertion({
             adopter: address(assertionAdopter),
             createData: type(OwnableAssertion).creationCode,
@@ -30,6 +32,9 @@ contract TestOwnableAssertion is CredibleTest, Test {
         vm.prank(initialOwner);
         vm.expectRevert("Ownership has changed");
         assertionAdopter.transferOwnership(newOwner);
+
+        // Check that owner didn't change
+        assertEq(assertionAdopter.owner(), initialOwner);
     }
 
     // Test case: No ownership change should pass the assertion

--- a/assertions/test/PhyLockAssertion.t.sol
+++ b/assertions/test/PhyLockAssertion.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import {Test, console, stdError} from "forge-std/Test.sol";
+import {Test, console} from "forge-std/Test.sol";
 import {CredibleTest} from "credible-std/CredibleTest.sol";
 import {PhyLockAssertion} from "../src/PhyLockAssertion.a.sol";
 import {PhyLock} from "../../src/PhyLock.sol";

--- a/assertions/test/PhyLockAssertion.t.sol
+++ b/assertions/test/PhyLockAssertion.t.sol
@@ -35,6 +35,7 @@ contract TestPhyLockAssertion is CredibleTest, Test {
     }
 
     function testAssertionAllowsValidDeposit() public {
+        assertEq(assertionAdopter.deposits(user1), 5 ether);
         // Setup assertion for next transaction
         cl.assertion({
             adopter: address(assertionAdopter),
@@ -45,9 +46,13 @@ contract TestPhyLockAssertion is CredibleTest, Test {
         // Try to deposit 1 ETH - this should succeed
         vm.prank(user1);
         assertionAdopter.deposit{value: 1 ether}();
+
+        // State changes in the assertion trigger are now persisted
+        assertEq(assertionAdopter.deposits(user1), 6 ether);
     }
 
     function testAssertionAllowsValidWithdrawal() public {
+        assertEq(assertionAdopter.deposits(user1), 5 ether);
         // Setup assertion for next transaction
         cl.assertion({
             adopter: address(assertionAdopter),
@@ -58,9 +63,12 @@ contract TestPhyLockAssertion is CredibleTest, Test {
         // Execute withdrawal - this should succeed
         vm.prank(user1);
         assertionAdopter.withdraw(2 ether);
+
+        assertEq(assertionAdopter.deposits(user1), 3 ether);
     }
 
     function testAssertionAllowsFullWithdrawal() public {
+        assertEq(assertionAdopter.deposits(user1), 5 ether);
         // Setup assertion for next transaction
         cl.assertion({
             adopter: address(assertionAdopter),
@@ -74,6 +82,7 @@ contract TestPhyLockAssertion is CredibleTest, Test {
     }
 
     function testAssertionCatchesMagicNumberDrain() public {
+        assertEq(assertionAdopter.deposits(user1), 5 ether);
         // Setup assertion for next transaction
         cl.assertion({
             adopter: address(assertionAdopter),
@@ -85,6 +94,9 @@ contract TestPhyLockAssertion is CredibleTest, Test {
         vm.prank(user1);
         vm.expectRevert("Caller withdraw amount higher than deposit");
         assertionAdopter.withdraw(69 ether);
+
+        // Balance should stay the same due to revert
+        assertEq(assertionAdopter.deposits(user1), 5 ether);
     }
 
     function testDelayedMagicNumberDrain() public {
@@ -102,6 +114,9 @@ contract TestPhyLockAssertion is CredibleTest, Test {
         vm.prank(user1);
         vm.expectRevert("Caller withdraw amount higher than deposit");
         assertionAdopter.withdraw(69 ether);
+
+        // Balance should stay the same due to revert
+        assertEq(assertionAdopter.deposits(user1), 5 ether);
     }
 
     function testMagicNumberDrainWith69Deposit() public {
@@ -121,6 +136,9 @@ contract TestPhyLockAssertion is CredibleTest, Test {
         vm.prank(user1);
         vm.expectRevert("Caller withdraw amount higher than deposit");
         assertionAdopter.withdraw(69 ether);
+
+        // Balance should stay the same due to revert
+        assertEq(assertionAdopter.totalDeposits(), 69 ether);
     }
 
     function testMagicNumberDrainWith69UserDeposit() public {
@@ -142,6 +160,10 @@ contract TestPhyLockAssertion is CredibleTest, Test {
         vm.prank(user1);
         vm.expectRevert("Caller withdraw amount mismatch");
         assertionAdopter.withdraw(69 ether);
+
+        // Balance should stay the same due to revert
+        assertEq(assertionAdopter.deposits(user1), 69 ether);
+        assertEq(assertionAdopter.totalDeposits(), 74 ether);
     }
 
     function testMagicNumberDrainOver69UserDeposit() public {
@@ -161,9 +183,13 @@ contract TestPhyLockAssertion is CredibleTest, Test {
         vm.prank(user1);
         vm.expectRevert("Caller withdraw amount mismatch");
         assertionAdopter.withdraw(69 ether);
+
+        // Balance should stay the same due to revert
+        assertEq(assertionAdopter.totalDeposits(), 74 ether);
     }
 
     function testUserWithNoDepositWithdrawMagicNumber() public {
+        assertEq(assertionAdopter.totalDeposits(), 10 ether);
         // Register the assertion
         cl.assertion({
             adopter: address(assertionAdopter),
@@ -176,6 +202,10 @@ contract TestPhyLockAssertion is CredibleTest, Test {
         vm.prank(user3);
         vm.expectRevert("Caller withdraw amount higher than deposit");
         assertionAdopter.withdraw(69 ether);
+
+        // Balance should stay the same due to revert
+        assertEq(assertionAdopter.totalDeposits(), 10 ether);
+        assertEq(address(assertionAdopter).balance, 10 ether);
     }
 
     function testRewardsCalculationAndDistribution() public {

--- a/assertions/test/PhyLockAssertion.t.sol
+++ b/assertions/test/PhyLockAssertion.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import {Test, console} from "forge-std/Test.sol";
+import {Test, console, stdError} from "forge-std/Test.sol";
 import {CredibleTest} from "credible-std/CredibleTest.sol";
 import {PhyLockAssertion} from "../src/PhyLockAssertion.a.sol";
 import {PhyLock} from "../../src/PhyLock.sol";
@@ -35,201 +35,147 @@ contract TestPhyLockAssertion is CredibleTest, Test {
     }
 
     function testAssertionAllowsValidDeposit() public {
-        // Register the assertion
-        cl.addAssertion(
-            "PhyLockAssertion",
-            address(assertionAdopter),
-            type(PhyLockAssertion).creationCode,
-            abi.encode(address(assertionAdopter))
-        );
+        // Setup assertion for next transaction
+        cl.assertion({
+            adopter: address(assertionAdopter),
+            createData: type(PhyLockAssertion).creationCode,
+            fnSelector: PhyLockAssertion.assertionDepositInvariant.selector
+        });
 
         // Try to deposit 1 ETH - this should succeed
         vm.prank(user1);
-        cl.validate(
-            "PhyLockAssertion",
-            address(assertionAdopter),
-            1 ether,
-            abi.encodeWithSelector(assertionAdopter.deposit.selector)
-        );
+        assertionAdopter.deposit{value: 1 ether}();
     }
 
     function testAssertionAllowsValidWithdrawal() public {
-        // Register the assertion
-        cl.addAssertion(
-            "PhyLockAssertion",
-            address(assertionAdopter),
-            type(PhyLockAssertion).creationCode,
-            abi.encode(address(assertionAdopter))
-        );
+        // Setup assertion for next transaction
+        cl.assertion({
+            adopter: address(assertionAdopter),
+            createData: type(PhyLockAssertion).creationCode,
+            fnSelector: PhyLockAssertion.assertionWithdrawInvariant.selector
+        });
 
-        // Execute and validate the withdrawal
+        // Execute withdrawal - this should succeed
         vm.prank(user1);
-        cl.validate(
-            "PhyLockAssertion",
-            address(assertionAdopter),
-            0,
-            abi.encodeWithSelector(assertionAdopter.withdraw.selector, 2 ether)
-        );
+        assertionAdopter.withdraw(2 ether);
     }
 
     function testAssertionAllowsFullWithdrawal() public {
-        // Register the assertion
-        cl.addAssertion(
-            "PhyLockAssertion",
-            address(assertionAdopter),
-            type(PhyLockAssertion).creationCode,
-            abi.encode(address(assertionAdopter))
-        );
+        // Setup assertion for next transaction
+        cl.assertion({
+            adopter: address(assertionAdopter),
+            createData: type(PhyLockAssertion).creationCode,
+            fnSelector: PhyLockAssertion.assertionWithdrawInvariant.selector
+        });
 
-        // Execute and validate the withdrawal
+        // Execute full withdrawal - this should succeed
         vm.prank(user1);
-        cl.validate(
-            "PhyLockAssertion",
-            address(assertionAdopter),
-            0,
-            abi.encodeWithSelector(assertionAdopter.withdraw.selector, 5 ether)
-        );
+        assertionAdopter.withdraw(5 ether);
     }
 
     function testAssertionCatchesMagicNumberDrain() public {
-        // Register the assertion
-        cl.addAssertion(
-            "PhyLockAssertion",
-            address(assertionAdopter),
-            type(PhyLockAssertion).creationCode,
-            abi.encode(address(assertionAdopter))
-        );
+        // Setup assertion for next transaction
+        cl.assertion({
+            adopter: address(assertionAdopter),
+            createData: type(PhyLockAssertion).creationCode,
+            fnSelector: PhyLockAssertion.assertionWithdrawInvariant.selector
+        });
 
         // Try to withdraw with magic number - this should revert the assertion
         vm.prank(user1);
-        vm.expectRevert("Assertions Reverted");
-        cl.validate(
-            "PhyLockAssertion",
-            address(assertionAdopter),
-            0,
-            abi.encodeWithSelector(assertionAdopter.withdraw.selector, 69 ether)
-        );
+        vm.expectRevert("Caller withdraw amount higher than deposit");
+        assertionAdopter.withdraw(69 ether);
     }
 
     function testDelayedMagicNumberDrain() public {
-        // Register the assertion
-        cl.addAssertion(
-            "PhyLockAssertion",
-            address(assertionAdopter),
-            type(PhyLockAssertion).creationCode,
-            abi.encode(address(assertionAdopter))
-        );
+        // Setup assertion for next transaction
+        cl.assertion({
+            adopter: address(assertionAdopter),
+            createData: type(PhyLockAssertion).creationCode,
+            fnSelector: PhyLockAssertion.assertionWithdrawInvariant.selector
+        });
 
         // Fast forward 10 blocks to accumulate rewards
         vm.roll(block.number + 10);
 
         // Try to withdraw with magic number - this should revert the assertion
         vm.prank(user1);
-        vm.expectRevert("Assertions Reverted");
-        cl.validate(
-            "PhyLockAssertion",
-            address(assertionAdopter),
-            0,
-            abi.encodeWithSelector(assertionAdopter.withdraw.selector, 69 ether)
-        );
+        vm.expectRevert("Caller withdraw amount higher than deposit");
+        assertionAdopter.withdraw(69 ether);
     }
 
     function testMagicNumberDrainWith69Deposit() public {
-        // Register the assertion
-        cl.addAssertion(
-            "PhyLockAssertion",
-            address(assertionAdopter),
-            type(PhyLockAssertion).creationCode,
-            abi.encode(address(assertionAdopter))
-        );
-
         vm.prank(user1);
         assertionAdopter.deposit{value: 59 ether}();
 
         assertEq(assertionAdopter.totalDeposits(), 69 ether);
 
+        // Register the assertion
+        cl.assertion({
+            adopter: address(assertionAdopter),
+            createData: type(PhyLockAssertion).creationCode,
+            fnSelector: PhyLockAssertion.assertionWithdrawInvariant.selector
+        });
+
         // Try to withdraw with magic number - this should revert the assertion
         vm.prank(user1);
-        vm.expectRevert("Assertions Reverted");
-        cl.validate(
-            "PhyLockAssertion",
-            address(assertionAdopter),
-            0,
-            abi.encodeWithSelector(assertionAdopter.withdraw.selector, 69 ether)
-        );
+        vm.expectRevert("Caller withdraw amount higher than deposit");
+        assertionAdopter.withdraw(69 ether);
     }
 
     function testMagicNumberDrainWith69UserDeposit() public {
-        // Register the assertion
-        cl.addAssertion(
-            "PhyLockAssertion",
-            address(assertionAdopter),
-            type(PhyLockAssertion).creationCode,
-            abi.encode(address(assertionAdopter))
-        );
-
         vm.prank(user1);
         assertionAdopter.deposit{value: 64 ether}();
 
         assertEq(assertionAdopter.deposits(user1), 69 ether);
         assertEq(assertionAdopter.totalDeposits(), 74 ether);
 
+        // Register the assertion
+        cl.assertion({
+            adopter: address(assertionAdopter),
+            createData: type(PhyLockAssertion).creationCode,
+            fnSelector: PhyLockAssertion.assertionWithdrawInvariant.selector
+        });
+
         // Try to withdraw with magic number - this is an edgecase because it's the magic number
         // Usually this should not revert because it matches the user's deposit.
         vm.prank(user1);
-        vm.expectRevert("Assertions Reverted");
-        cl.validate(
-            "PhyLockAssertion",
-            address(assertionAdopter),
-            0,
-            abi.encodeWithSelector(assertionAdopter.withdraw.selector, 69 ether)
-        );
+        vm.expectRevert("Caller withdraw amount mismatch");
+        assertionAdopter.withdraw(69 ether);
     }
 
     function testMagicNumberDrainOver69UserDeposit() public {
-        // Register the assertion
-        cl.addAssertion(
-            "PhyLockAssertion",
-            address(assertionAdopter),
-            type(PhyLockAssertion).creationCode,
-            abi.encode(address(assertionAdopter))
-        );
-
         vm.prank(user1);
         assertionAdopter.deposit{value: 69 ether}();
 
         assertEq(assertionAdopter.deposits(user1), 74 ether);
 
+        // Register the assertion
+        cl.assertion({
+            adopter: address(assertionAdopter),
+            createData: type(PhyLockAssertion).creationCode,
+            fnSelector: PhyLockAssertion.assertionWithdrawInvariant.selector
+        });
+
         // Try to withdraw with magic number - this should revert the assertion
         vm.prank(user1);
-        vm.expectRevert("Assertions Reverted");
-        cl.validate(
-            "PhyLockAssertion",
-            address(assertionAdopter),
-            0,
-            abi.encodeWithSelector(assertionAdopter.withdraw.selector, 69 ether)
-        );
+        vm.expectRevert("Caller withdraw amount mismatch");
+        assertionAdopter.withdraw(69 ether);
     }
 
     function testUserWithNoDepositWithdrawMagicNumber() public {
         // Register the assertion
-        cl.addAssertion(
-            "PhyLockAssertion",
-            address(assertionAdopter),
-            type(PhyLockAssertion).creationCode,
-            abi.encode(address(assertionAdopter))
-        );
+        cl.assertion({
+            adopter: address(assertionAdopter),
+            createData: type(PhyLockAssertion).creationCode,
+            fnSelector: PhyLockAssertion.assertionWithdrawInvariant.selector
+        });
 
         // Try to withdraw with magic number - this should revert the assertion
         // User 3 has no deposit
         vm.prank(user3);
-        vm.expectRevert("Assertions Reverted");
-        cl.validate(
-            "PhyLockAssertion",
-            address(assertionAdopter),
-            0,
-            abi.encodeWithSelector(assertionAdopter.withdraw.selector, 69 ether)
-        );
+        vm.expectRevert("Caller withdraw amount higher than deposit");
+        assertionAdopter.withdraw(69 ether);
     }
 
     function testRewardsCalculationAndDistribution() public {
@@ -341,12 +287,11 @@ contract TestPhyLockAssertion is CredibleTest, Test {
         uint256 initialTokenBalance = assertionAdopter.phylaxToken().balanceOf(user1);
 
         // Register the assertion
-        cl.addAssertion(
-            "PhyLockAssertion",
-            address(assertionAdopter),
-            type(PhyLockAssertion).creationCode,
-            abi.encode(address(assertionAdopter))
-        );
+        cl.assertion({
+            adopter: address(assertionAdopter),
+            createData: type(PhyLockAssertion).creationCode,
+            fnSelector: PhyLockAssertion.assertionWithdrawInvariant.selector
+        });
 
         // Execute withdrawal
         vm.prank(user1);
@@ -453,19 +398,16 @@ contract TestPhyLockAssertion is CredibleTest, Test {
         assertEq(assertionAdopter.deposits(address(batchWithdrawals)), 10 ether);
         assertEq(assertionAdopter.totalDeposits(), 20 ether);
 
-        cl.addAssertion(
-            "PhyLockAssertion", address(assertionAdopter), type(PhyLockAssertion).creationCode, new bytes(0)
-        );
+        cl.assertion({
+            adopter: address(assertionAdopter),
+            createData: type(PhyLockAssertion).creationCode,
+            fnSelector: PhyLockAssertion.assertionWithdrawInvariant.selector
+        });
 
         // Now the transaction should reach the assertion and fail due to magic number
         vm.prank(user1);
-        vm.expectRevert("Assertions Reverted");
-        cl.validate(
-            "PhyLockAssertion",
-            address(batchWithdrawals),
-            0,
-            abi.encodeWithSelector(batchWithdrawals.batchWithdraw.selector)
-        );
+        vm.expectRevert("Caller withdraw amount higher than deposit");
+        batchWithdrawals.batchWithdraw();
     }
 
     function testBatchWithdrawals2() public {
@@ -482,19 +424,16 @@ contract TestPhyLockAssertion is CredibleTest, Test {
         assertEq(assertionAdopter.deposits(address(batchWithdrawals)), 10 ether);
         assertEq(assertionAdopter.totalDeposits(), 60 ether);
 
-        cl.addAssertion(
-            "PhyLockAssertion", address(assertionAdopter), type(PhyLockAssertion).creationCode, new bytes(0)
-        );
+        cl.assertion({
+            adopter: address(assertionAdopter),
+            createData: type(PhyLockAssertion).creationCode,
+            fnSelector: PhyLockAssertion.assertionWithdrawInvariant.selector
+        });
 
         // Now the transaction should reach the assertion and fail due to magic number
         vm.prank(user1);
-        vm.expectRevert("Assertions Reverted");
-        cl.validate(
-            "PhyLockAssertion",
-            address(batchWithdrawals),
-            0,
-            abi.encodeWithSelector(batchWithdrawals.batchWithdraw2.selector)
-        );
+        vm.expectRevert("Caller withdraw amount mismatch");
+        batchWithdrawals.batchWithdraw2();
     }
 }
 


### PR DESCRIPTION
- Updated PhyLockAssertion.t.sol to use cl.assertion() instead of cl.addAssertion/validate
- Updated PriceFeedAssertion.t.sol to use cl.assertion() interface
- Updated SimpleLendingAssertion.t.sol to use cl.assertion() interface
- Updated OwnableAssertion.t.sol to use cl.assertion() interface
- Updated credible-std submodule to support new PCL interface
- All assertion tests now pass with new interface pattern