### PR TITLE
ci: install pcl from phylaxsystems/pcl release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
 
       - name: Install PCL CLI
         run: |
-          LATEST_VERSION=$(curl -s https://api.github.com/repos/phylaxsystems/credible-sdk/releases/latest | grep '"tag_name":' | cut -d'"' -f4)
-          curl -L "https://github.com/phylaxsystems/credible-sdk/releases/download/${LATEST_VERSION}/pcl-${LATEST_VERSION}-linux-x86_64.tar.gz" | tar -xz
+          LATEST_VERSION=$(curl -s https://api.github.com/repos/phylaxsystems/pcl/releases/latest | grep '"tag_name":' | cut -d'"' -f4)
+          curl -L "https://github.com/phylaxsystems/pcl/releases/download/${LATEST_VERSION}/pcl-${LATEST_VERSION}-linux-x86_64.tar.gz" | tar -xz
           sudo mv pcl/pcl /usr/local/bin/
           sudo chmod +x /usr/local/bin/pcl
 


### PR DESCRIPTION
## Summary

Updates the CI to install the \`pcl\` binary from \`phylaxsystems/pcl\` releases instead of \`phylaxsystems/credible-sdk\` releases.

PCL now has its own dedicated release repository.

## Test plan

- [ ] CI runs successfully and installs the latest pcl release